### PR TITLE
Fix disappearing probability mass

### DIFF
--- a/policy_improvement/categorical_update.py
+++ b/policy_improvement/categorical_update.py
@@ -88,6 +88,9 @@ class CategoricalPolicyImprovement(object):
         b = (bellman_op - self.v_min) / self.delta_z
         l = b.floor().long()
         u = b.ceil().long()
+        # Fix disappearing probability mass when l = b = u (b is int)
+        l[(u > 0) * (l == u)] -= 1
+        u[(l < (self.atoms_no - 1)) * (l == u)] += 1
 
         # Distribute probability
         """


### PR DESCRIPTION
Closes #1. Not sure if this is the best way to deal with the problem, but it seems to cover a few cases - let me know if you have a better solution.

So to provide an example on the issue, the update relies on `qa_probs * (u.float() - b)` and `qa_probs * (b - l.float())`, but if `b` happens to contain any ints (e.g. in a terminal state where all probability mass is concentrated in one location), then both of these parts of the update turn into `qa_probs * 0` and hence the network tries matching a vector of 0s with its softmax output, which will obviously cause problems. Due to the nature of this edge case I believe it has a worse effect on environments with more terminal transitions.