### PR TITLE
Reduce clamping

### DIFF
--- a/policy_improvement/categorical_update.py
+++ b/policy_improvement/categorical_update.py
@@ -50,7 +50,7 @@ class CategoricalPolicyImprovement(object):
         target_qa_probs = self._get_categorical(next_states, rewards, mask)
 
         # Compute the cross-entropy of phi(TZ(x_,a)) || Z(x,a)
-        qa_probs.data.clamp_(0.01, 0.99)  # Tudor's trick for avoiding nans
+        qa_probs = qa_probs.clamp(min=1e-3)  # Tudor's trick for avoiding nans
         loss = - torch.sum(target_qa_probs * torch.log(qa_probs))
 
         # Accumulate gradients


### PR DESCRIPTION
Closes #3. As discussed previously, a max clamp shouldn't be needed. I haven't decoupled the effects of a min clamp of 0.01 versus 0.001, but the latter seems to work fine for my experiments.